### PR TITLE
Setting Content-Type Response Header

### DIFF
--- a/common/model.go
+++ b/common/model.go
@@ -103,6 +103,7 @@ func RespondWithJSON(w http.ResponseWriter, r *http.Request, status int, data in
 		return
 	}
 	w.WriteHeader(status)
+	w.Header().Set("Content-Type", "application/json")
 	_, err = io.Copy(w, &buf)
 	if err != nil {
 		log.Println("RespondWithJSON:", err)


### PR DESCRIPTION
Explicitly setting `Content-Type` to `application/json` for all successful json responses

Fix for #29