### PR TITLE
feat(docker): reduce the docker image by using multistage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM golang:1.11
+FROM golang:1.11 as builder
+WORKDIR /go/src/github.com/kshitij10496/hercules/
+ADD . /go/src/github.com/kshitij10496/hercules
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o hercules .
 
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
 ENV PORT=8080
 ENV HERCULES_DATABASE="user=kshitij10496 dbname=herculesdb sslmode=disable"
-
-RUN mkdir -p /go/src/github.com/kshitij10496/hercules
-WORKDIR /go/src/github.com/kshitij10496/hercules
-ADD . /go/src/github.com/kshitij10496/hercules
-
-RUN go build .
-
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/kshitij10496/hercules/hercules .
 CMD ["./hercules"]
-
 EXPOSE 8080


### PR DESCRIPTION
Image before the PR:
```console
hercules          latest          d92999095a87          28 seconds ago          790MB
```

Image after the PR:
```console
hercules          latest          771951a7056b          6 seconds ago          14.9MB
```

## How it works ?

By using Mulitstage Dockerfile you can define several docker images and copy/paste files from one of them to another. By this way it's possible to have a first image that build the binary of Hercules (From golang) and a second to execute the binary (From scratch or alpine) to reduce the size of the final docker image.

### Reference

https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds